### PR TITLE
Use template instead of href for FEP-3b86 intent links

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -23,4 +23,8 @@ const RelationTypeSelf = "self"
 // See: https://pubsubhubbub.github.io/PubSubHubbub/pubsubhubbub-core-0.4.html#anchor4
 const RelationTypeHub = "hub"
 
+// RelationTypeFEP3b86Prefix is the prefix for FEP-3b86 interaction links.
+// See: https://w3id.org/fep/3b86/
+const RelationTypeFEP3b86Prefix = "https://w3id.org/fep/3b86/"
+
 // Additional values to consider adding: http://microformats.org/wiki/existing-rel-values

--- a/link.go
+++ b/link.go
@@ -1,6 +1,8 @@
 package digit
 
 import (
+	"strings"
+
 	"github.com/benpate/rosetta/mapof"
 )
 
@@ -26,7 +28,8 @@ func NewLink(relationType string, mediaType string, href string) Link {
 	}
 
 	// Special case for oStatus subscribe requests
-	if relationType == RelationTypeSubscribeRequest {
+	// and FEP-3b86 intent links
+	if relationType == RelationTypeSubscribeRequest || strings.HasPrefix(relationType, RelationTypeFEP3b86Prefix) {
 		result.Template = result.Href
 		result.Href = ""
 	}

--- a/link_test.go
+++ b/link_test.go
@@ -148,6 +148,33 @@ func TestCreateLinkWithSubscribeRequest(t *testing.T) {
 	require.Equal(t, RelationTypeSubscribeRequest, link.RelationType)
 }
 
+func TestCreateLinkWithFEP3b86(t *testing.T) {
+
+	link := NewLink(RelationTypeFEP3b86Prefix+"Create", "", "https://www.example.com/intent/create?type={type}&content={content}")
+
+	require.Equal(t, "https://www.example.com/intent/create?type={type}&content={content}", link.Template)
+	require.Equal(t, "", link.Href)
+	require.Equal(t, RelationTypeFEP3b86Prefix+"Create", link.RelationType)
+}
+
+func TestCreateLinkWithFEP3b86Follow(t *testing.T) {
+
+	link := NewLink(RelationTypeFEP3b86Prefix+"Follow", "", "https://www.example.com/intent/follow?object={object}")
+
+	require.Equal(t, "https://www.example.com/intent/follow?object={object}", link.Template)
+	require.Equal(t, "", link.Href)
+	require.Equal(t, RelationTypeFEP3b86Prefix+"Follow", link.RelationType)
+}
+
+func TestCreateLinkWithFEP3b86Like(t *testing.T) {
+
+	link := NewLink(RelationTypeFEP3b86Prefix+"Like", "", "https://www.example.com/intent/like?object={object}")
+
+	require.Equal(t, "https://www.example.com/intent/like?object={object}", link.Template)
+	require.Equal(t, "", link.Href)
+	require.Equal(t, RelationTypeFEP3b86Prefix+"Like", link.RelationType)
+}
+
 func TestUnmarshalLinkWithSubscribeRequest(t *testing.T) {
 
 	link := Link{}


### PR DESCRIPTION
## Summary

- Emissary's WebFinger endpoint outputs FEP-3b86 intent links with `href` instead of `template`. Since these links contain URI template variables (e.g. `{object}`, `{type}`), the [FEP-3b86 spec](https://w3id.org/fep/3b86/) requires them to use the `template` property.
- This extends the existing special-case logic in `NewLink` (used for oStatus subscribe requests) to also apply to relation types prefixed with `https://w3id.org/fep/3b86/`.
- Adds a `RelationTypeFEP3b86Prefix` constant and tests for Create, Follow, and Like intent links.

https://webfinger.net/lookup/?resource=https%3A%2F%2Fbandwagon.fm%2F%40pfefferle